### PR TITLE
Fix typo in style.js

### DIFF
--- a/style.js
+++ b/style.js
@@ -50,7 +50,7 @@ let style = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center'
   },
-  btnTextText: {
+  btnTextConfirm: {
     fontSize: 16,
     color: '#46cf98'
   },


### PR DESCRIPTION
I found a typo when trying to add custom styles to my date picker. It should be btnTextConfirm to add styles to the confirmation button.